### PR TITLE
Add support for meshviewer.json as well as an option for domain filter

### DIFF
--- a/ffflash/inc/meshviewer.py
+++ b/ffflash/inc/meshviewer.py
@@ -1,0 +1,104 @@
+from ffflash.inc.rankfile import handle_rankfile
+from ffflash.lib.files import check_file_location, load_file
+from ffflash.lib.remote import fetch_www_struct
+from ffflash.lib.text import replace_text
+
+def _meshviewer_fetch(ff):
+    if not ff.access_for('meshviewer'):
+        return False
+
+    ff.log('fetching meshviewer data {}'.format(ff.args.nodelist))
+
+    nodes = (
+        load_file(ff.args.meshviewer, fallback=None, as_yaml=False)
+        if check_file_location(ff.args.meshviewer, must_exist=True) else
+        fetch_www_struct(ff.args.meshviewer, fallback=None, as_yaml=False)
+    )
+
+    if not nodes or not isinstance(nodes, dict):
+        return ff.log(
+            'could not fetch meshviewer file {}'.format(ff.args.nodelist),
+            level=False
+        )
+
+    if not all([(a in nodes) for a in ['links', 'nodes', 'timestamp']]):
+        return ff.log(
+            'this is no nodelist {}'.format(ff.args.nodelist),
+            level=False
+        )
+
+    ff.log('successfully fetched meshviewer data from {}'.format(ff.args.nodelist))
+    return nodes.get("nodes", [])
+
+def _node_count(ff, nodes):
+    domain = ff.args.domain
+
+    relevant_nodes = [
+        node for node in nodes
+            if node.get('is_online', False) and (domain is None or domain == node.get("domain"))
+    ]
+
+    clients = sum([node.get('clients', 0) for node in relevant_nodes])
+
+    return len(relevant_nodes), clients, relevant_nodes
+
+def _meshviewer_dump(ff, nodes, clients):
+    '''
+    Store the counted numbers in the api-file.
+
+    Sets the key ``state`` . ``nodes`` with the node number.
+
+    Leaves ``state`` . ``description`` untouched, if any already present.
+    If empty, or the pattern ``\[[\d]+ Nodes, [\d]+ Clients\]`` is matched,
+    the numbers in the pattern will be replaced.
+
+    :param ff: running :class:`ffflash.main.FFFlash` instance
+    :param nodes: Number of online nodes
+    :param clients: Number of their clients
+    :return: ``True`` if :attr:`api` was modified else ``False``
+    '''
+    if not ff.access_for('meshviewer'):
+        return False
+
+    modified = []
+    if ff.api.pull('state', 'nodes') is not None:
+        ff.api.push(nodes, 'state', 'nodes')
+        ff.log('stored {} in state.nodes'.format(nodes))
+        modified.append(True)
+
+    descr = ff.api.pull('state', 'description')
+    if descr is not None:
+        new = '[{} Nodes, {} Clients]'.format(nodes, clients)
+        new_descr = (replace_text(
+            r'(\[[\d]+ Nodes, [\d]+ Clients\])', new, descr
+        ) if descr else new)
+        ff.api.push(new_descr, 'state', 'description')
+        ff.log('stored {} nodes and {} clients in state.description'.format(
+            nodes, clients
+        ))
+        modified.append(True)
+
+    return any(modified)
+
+def handle_meshviewer(ff):
+    if not ff.access_for('meshviewer'):
+        return False
+
+    nodes = _meshviewer_fetch(ff)
+    if not nodes:
+        return False
+
+    modified = []
+
+    node_count, clients, relevant_nodes = _node_count(ff, nodes)
+    if all([nodes, clients]):
+        modified.append(
+            _meshviewer_dump(ff, node_count, clients)
+        )
+
+    if ff.access_for('rankfile'):
+        modified.append(
+            handle_rankfile(ff, relevant_nodes)
+        )
+
+    return any(modified)

--- a/ffflash/lib/args.py
+++ b/ffflash/lib/args.py
@@ -30,6 +30,10 @@ def parsed_args(argv=None):
         help='URL or location to map\'s nodelist.json, updates nodes count'
     )
     parser.add_argument(
+        '-m', '--meshviewer', action='store',
+        help='URL or location to map\'s meshviewer.json, updates nodes count'
+    )
+    parser.add_argument(
         '-r', '--rankfile', action='store',
         help='location to rankfile.json, for node statistics and credits'
     )
@@ -61,11 +65,15 @@ def parsed_args(argv=None):
         '-v', '--verbose', action='store_true',
         help='show verbose output'
     )
+    parser.add_argument(
+        '-D', '--domain', action='store',
+        help='filter by subcommunity'
+    )
 
     args = parser.parse_args(
         argv if (argv is not None) else _argv[1:]
     )
 
-    if args.rankfile and not args.nodelist:
-        parser.error('argument -r/--rankfile: needs a -n/--nodelist')
+    if args.rankfile and not (args.nodelist or args.meshviewer):
+        parser.error('argument -r/--rankfile: needs a -n/--nodelist or a -m/--meshviewer')
     return args

--- a/ffflash/main.py
+++ b/ffflash/main.py
@@ -1,5 +1,6 @@
 from ffflash.inc.nodelist import handle_nodelist
 from ffflash.inc.sidecars import handle_sidecars
+from ffflash.inc.meshviewer import handle_meshviewer
 from ffflash.info import info
 from ffflash.lib.api import FFApi
 from ffflash.lib.args import parsed_args
@@ -65,8 +66,9 @@ class FFFlash:
                 'api': self.location,
                 'sidecars': self.args.sidecars,
                 'nodelist': self.args.nodelist,
+                'meshviewer': self.args.meshviewer,
                 'rankfile': all([
-                    self.args.nodelist, self.args.rankfile
+                    (self.args.meshviewer or self.args.nodelist), self.args.rankfile
                 ]),
             }.get(name, False)
         ])
@@ -115,6 +117,11 @@ def run(argv=None):
     if ff.access_for('nodelist'):
         modified.append(
             handle_nodelist(ff)
+        )
+
+    if ff.access_for('meshviewer'):
+        modified.append(
+            handle_meshviewer(ff)
         )
 
     if ff.args.dry:


### PR DESCRIPTION
I have added support for the newer meshviewer format. The format also supports multidomain, so that multiple communities share a map. To use the meshviewer format, specify the `-m/--meshviewer` CLI option instead of `-n/--nodelist`.
In such setups you will need a separate api-file per domain, so i have added an option `-D/--domain` to filter by this value.

This is a non-breaking change. All existing functionality remains untouched.